### PR TITLE
Added vehicles to services page template

### DIFF
--- a/app/wp-content/themes/kstg/page-services.php
+++ b/app/wp-content/themes/kstg/page-services.php
@@ -12,5 +12,21 @@
         <h2><?php the_field('service_type'); ?></h2>
         <img src="<?php echo $image['url'] ?>" width="500" height="200" />
         <?php the_field('service_description'); ?>
+
+        <h3>Recommended Rides</h3>
+        <?php $vehicles = get_field('recommended_rides');
+
+        if ( $vehicles ): ?>
+          <ul>
+            <?php foreach ( $vehicles as $post ): ?>
+              <?php setup_postdata($post); ?>
+              <li>
+                <img src="<?php echo get_field('hero_image')['url']?>" alt="<?php echo get_field('hero_image')['alt']?>" />
+                <a href="<?php the_permalink(); ?>"><?php the_field('vehicle_type'); ?></a>
+              </li>
+            <?php endforeach; ?>
+          </ul>
+          <?php wp_reset_postdata(); ?>
+        <?php endif; ?>
       </div>
 <?php get_footer(); ?>


### PR DESCRIPTION
There may be merge conflicts that need to be resolved if this is merged after the other updates to the services page template. This change is pretty small, though, so it should be easy. I didn't update the database so that you know how to do it and can show Kevin. It's super super simple!

First, in the 'Custom Fields' setting, add a new field for the vehicles. You don't have to name things the same as what I did, and figured you'd want to add some other details. The only important one is 'recommended-rides' for the field name because this is what the code uses to pull them in.
![image](https://cloud.githubusercontent.com/assets/1372292/9029236/94dd26d0-3944-11e5-9b5b-56b6be08f91f.png)
![image](https://cloud.githubusercontent.com/assets/1372292/9029238/9acbccae-3944-11e5-84f9-3f61a8cf8e08.png)

And then in the actual template, he just chooses whichever cars he wants to feature!
![image](https://cloud.githubusercontent.com/assets/1372292/9029243/ab1a691c-3944-11e5-8e9a-21cb120bf42b.png)
