### PR TITLE
Added grunt tasks for pushing/pull, Updated wordpress submodule

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -131,15 +131,6 @@ module.exports = function(grunt) {
           ssh: true,
           delete: true
         }
-      },
-      update_wordpress_prod: {
-        options: {
-          args: ['--verbose', '--progress', '-rlt', '--compress', '--omit-dir-times'],
-          src: '<%= localConfig.local_repo_path %>/app/wordpress/',
-          dest: 'kevinsmithgroup@kevinsmithgroup.com:/home/kevinsmithgroup/wordpress/wordpress/',
-          ssh: true,
-          delete: true
-        }
       }
     },
     prompt: {
@@ -180,25 +171,6 @@ module.exports = function(grunt) {
             }
           }
         }
-      },
-      update_wordpress_prod: {
-        options: {
-          questions: [
-            {
-              config: 'continue',
-              type: 'confirm',
-              message: 'Did you update the Wordpress submodule locally?',
-              default: false
-            }
-          ],
-          then: function(results, done) {
-            if (results.continue) {
-              done();
-            } else {
-              grunt.fail.warn('Before you run this task, you need to update wordpress via git: `git submodule foreach git pull origin master`');
-            }
-          }
-        }
       }
     }
   });
@@ -216,7 +188,6 @@ module.exports = function(grunt) {
   grunt.registerTask('pull_prod', ['rsync:pull_uploads_prod', 'rsync:pull_plugins_prod']);
   grunt.registerTask('push', ['push_db', 'rsync:push_uploads', 'rsync:push_plugins']);
   grunt.registerTask('deploy_theme', ['prompt:git_master', 'rsync:deploy_theme']);
-  grunt.registerTask('update_wordpress_prod', ['prompt:update_wordpress_prod', 'rsync:update_wordpress_prod']);
   grunt.registerTask('deploy_theme_prod', ['prompt:git_master_prod', 'rsync:deploy_theme_prod']);
 
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -67,10 +67,28 @@ module.exports = function(grunt) {
           delete: true
         }
       },
+      pull_uploads_prod: {
+        options: {
+          args: ['--verbose', '--progress', '-rlt', '--compress', '--omit-dir-times'],
+          src: 'kevinsmithgroup@kevinsmithgroup.com:/home/kevinsmithgroup/wordpress/wp-content/uploads/',
+          dest: '<%= localConfig.local_repo_path %>/app/wp-content/uploads/',
+          ssh: true,
+          delete: true
+        }
+      },
       pull_plugins: {
         options: {
           args: ['--verbose', '--progress', '-rlt', '--compress', '--omit-dir-times'],
           src: '<%= localConfig.server_user %>@dev.derrickshowers.com:/var/www/sites/kstg/wp-content/plugins/',
+          dest: '<%= localConfig.local_repo_path %>/app/wp-content/plugins/',
+          ssh: true,
+          delete: true
+        }
+      },
+      pull_plugins_prod: {
+        options: {
+          args: ['--verbose', '--progress', '-rlt', '--compress', '--omit-dir-times'],
+          src: 'kevinsmithgroup@kevinsmithgroup.com:/home/kevinsmithgroup/wordpress/wp-content/plugins/',
           dest: '<%= localConfig.local_repo_path %>/app/wp-content/plugins/',
           ssh: true,
           delete: true
@@ -103,6 +121,25 @@ module.exports = function(grunt) {
           ssh: true,
           delete: true
         }
+      },
+      deploy_theme_prod: {
+        options: {
+          args: ['--verbose', '--progress', '-rlt', '--compress', '--omit-dir-times'],
+          exclude: ['scss','.sass-cache'],
+          src: '<%= localConfig.local_repo_path %>/app/wp-content/themes/kstg/',
+          dest: 'kevinsmithgroup@kevinsmithgroup.com:/home/kevinsmithgroup/wordpress/wp-content/themes/kstg/',
+          ssh: true,
+          delete: true
+        }
+      },
+      update_wordpress_prod: {
+        options: {
+          args: ['--verbose', '--progress', '-rlt', '--compress', '--omit-dir-times'],
+          src: '<%= localConfig.local_repo_path %>/app/wordpress/',
+          dest: 'kevinsmithgroup@kevinsmithgroup.com:/home/kevinsmithgroup/wordpress/wordpress/',
+          ssh: true,
+          delete: true
+        }
       }
     },
     prompt: {
@@ -124,6 +161,44 @@ module.exports = function(grunt) {
             }
           }
         }
+      },
+      git_master_prod: {
+        options: {
+          questions: [
+            {
+              config: 'continue',
+              type: 'confirm',
+              message: 'You are about to deploy the kstg theme to PRODUCTION. Are you sure you\'re on master?',
+              default: false
+            }
+          ],
+          then: function(results, done) {
+            if (results.continue) {
+              done();
+            } else {
+              grunt.fail.warn('Please make sure you\'re deploying master');
+            }
+          }
+        }
+      },
+      update_wordpress_prod: {
+        options: {
+          questions: [
+            {
+              config: 'continue',
+              type: 'confirm',
+              message: 'Did you update the Wordpress submodule locally?',
+              default: false
+            }
+          ],
+          then: function(results, done) {
+            if (results.continue) {
+              done();
+            } else {
+              grunt.fail.warn('Before you run this task, you need to update wordpress via git: `git submodule foreach git pull origin master`');
+            }
+          }
+        }
       }
     }
   });
@@ -138,7 +213,10 @@ module.exports = function(grunt) {
   // tasks
   grunt.registerTask('dev', ['watch']);
   grunt.registerTask('pull', ['pull_db', 'rsync:pull_uploads', 'rsync:pull_plugins']);
+  grunt.registerTask('pull_prod', ['rsync:pull_uploads_prod', 'rsync:pull_plugins_prod']);
   grunt.registerTask('push', ['push_db', 'rsync:push_uploads', 'rsync:push_plugins']);
   grunt.registerTask('deploy_theme', ['prompt:git_master', 'rsync:deploy_theme']);
+  grunt.registerTask('update_wordpress_prod', ['prompt:update_wordpress_prod', 'rsync:update_wordpress_prod']);
+  grunt.registerTask('deploy_theme_prod', ['prompt:git_master_prod', 'rsync:deploy_theme_prod']);
 
 };


### PR DESCRIPTION
- New task for pulling assets from prod: `grunt pull_prod` (note: this does not pull the database, that has to be done manually through phpmyadmin).
- New task for pushing theme to prod: `grunt deploy_theme_prod`
- Updated Wordpress submodule.

I originally had a task to push the updated submodule to production, but I think it's better if the updates are managed through the dashboard in prod (e.g. logging into the admin account and clicking 'update wordpress'). The submodule can just be used for local development.
